### PR TITLE
Remove 30d window

### DIFF
--- a/app/domino_cost.py
+++ b/app/domino_cost.py
@@ -55,9 +55,8 @@ breakdown_to_param = {
 
 
 # For granular aggregations
-window_options = ["Last 30 days", "Last 15 days", "Last week", "Today"]
+window_options = ["Last 15 days", "Last week", "Today"]
 window_to_param = {
-    "Last 30 days": "30d",
     "Last 15 days": "15d",
     "Last week": "lastweek",
     "Today": "today",


### PR DESCRIPTION
30d window remove from app dashboard because it's not supported anymore by free kubecost